### PR TITLE
The dependency on WinRPM has to be enclosed with @windows.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6
 BinDeps
 MultivariateStats
-WinRPM
+@windows WinRPM


### PR DESCRIPTION
Did not include the Windows guard before WinRPM which creates unnecessary errors in non-Windows builds. Now fixed. 